### PR TITLE
Transmitter should hold strong ref to Receiver

### DIFF
--- a/Receiver/Sources/Receiver.swift
+++ b/Receiver/Sources/Receiver.swift
@@ -78,14 +78,14 @@ public extension Receiver {
 
 public extension Receiver {
     struct Transmitter: Transmittable {
-        private weak var receiver: Receiver?
+        private let receiver: Receiver
 
         init(_ receiver: Receiver) {
             self.receiver = receiver
         }
 
         public func broadcast(_ wave: Wave) {
-            receiver?.append(value: wave)
+            receiver.append(value: wave)
         }
     }
 }

--- a/ReceiverTests/ReceiverTests.swift
+++ b/ReceiverTests/ReceiverTests.swift
@@ -142,4 +142,19 @@ class ReceiverTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func test_weakness() {
+        
+        var outterTransmitter: Receiver<Int>.Transmitter?
+        weak var outterReceiver: Receiver<Int>?
+        
+        autoreleasepool {
+            let (transmitter, receiver) = Receiver<Int>.make()
+            outterTransmitter = transmitter
+            outterReceiver = receiver
+        }
+        
+        XCTAssertNotNil(outterTransmitter)
+        XCTAssertNotNil(outterReceiver)
+    }
 }


### PR DESCRIPTION
If this is not the case, then a consumer needs to hold the reference to the receiver, which might be slightly awkward. Using the approach ReactiveSwift with Signal+Observer. 