### PR TITLE
[Suggestion + Implementation] Add combine operator and tests

### DIFF
--- a/ReceiverTests/ReceiverTests+Operators.swift
+++ b/ReceiverTests/ReceiverTests+Operators.swift
@@ -179,4 +179,26 @@ class ReceiverTests_Operators: XCTestCase {
 
         XCTAssertTrue(called == 3)
     }
+    
+    func test_combine() {
+        let (intTransmitter, intReceiver) = Receiver<Int>.make()
+        let (stringTransmitter, stringReceiver) = Receiver<String>.make()
+        let newReceiver = combine(intReceiver, stringReceiver)
+        let expectedValues = [(1,"1"),(2,"1"),(2,"2")]
+        var values = [(Int,String)]()
+
+        newReceiver.listen { wave in
+            values.append(wave)
+        }
+        
+        intTransmitter.broadcast(1)
+        stringTransmitter.broadcast("1")
+        intTransmitter.broadcast(2)
+        stringTransmitter.broadcast("2")
+        
+        XCTAssertEqual(values.map{$0.0}, expectedValues.map{$0.0})
+        XCTAssertEqual(values.map{$0.1}, expectedValues.map{$0.1})
+
+    }
+
 }


### PR DESCRIPTION
Add a function of type:
```swift
func combine<A,B>(_ ra: Receiver<A>, _ rb: Receiver<B>) -> Receiver<(A,B)> 
```
Discussion points:
- Whether it is necessary 😊 
- should it be a free function or method on a receiver (or both) i.e
```swift
let r3 = combine(r1,r2)
//vs
let r3 = r1.combine(r2)
```
- Code styling, this is a first pass at an implementation.
- Waiting semantics, whether we give values of (A?,B?) or similar when one side has not received a value yet.
