### PR TITLE
[Fix] Update key generation for adding handlers

### DIFF
--- a/Receiver/Sources/Receiver.swift
+++ b/Receiver/Sources/Receiver.swift
@@ -107,7 +107,10 @@ public class Receiver<Wave> {
     @discardableResult public func listen(to handle: @escaping (Wave) -> Void) -> Disposable {
         var _key: Int!
             handlers.apply { _handlers in
-                _key = _handlers.count
+                _key = Int.random(in: Int.min...Int.max)
+                while _handlers[_key] != nil {
+                    _key = Int.random(in: Int.min...Int.max)
+                }
                 _handlers[_key] = handle
             }
         switch strategy {

--- a/Receiver/Sources/Receiver.swift
+++ b/Receiver/Sources/Receiver.swift
@@ -106,11 +106,10 @@ public class Receiver<Wave> {
     /// - returns: A reference to a disposable
     @discardableResult public func listen(to handle: @escaping (Wave) -> Void) -> Disposable {
         var _key: Int!
-        handlers.apply { _handlers in
-            _key = (_handlers.keys.map { $0.hashValue }.max() ?? -1) + 1
-            _handlers[_key] = handle
-        }
-
+            handlers.apply { _handlers in
+                _key = _handlers.count
+                _handlers[_key] = handle
+            }
         switch strategy {
         case .cold:
             broadcast(elements: Int.max)

--- a/Receiver/Sources/Receiver.swift
+++ b/Receiver/Sources/Receiver.swift
@@ -68,7 +68,8 @@ public class Receiver<Wave> {
 
     private let values = Atomic<[Wave]>([])
     private let strategy: Strategy
-    private let handlers = Atomic<[Int:Handler]>([:])
+    private let handlers = Atomic<[UInt64:Handler]>([:])
+    private var nextKey: UInt64 = 0
 
     private init(strategy: Strategy) {
         self.strategy = strategy
@@ -105,13 +106,11 @@ public class Receiver<Wave> {
     ///             a new value is sent.
     /// - returns: A reference to a disposable
     @discardableResult public func listen(to handle: @escaping (Wave) -> Void) -> Disposable {
-        var _key: Int!
+        var _key: UInt64!
             handlers.apply { _handlers in
-                _key = Int.random(in: Int.min...Int.max)
-                while _handlers[_key] != nil {
-                    _key = Int.random(in: Int.min...Int.max)
-                }
+                _key = nextKey
                 _handlers[_key] = handle
+                nextKey = nextKey &+ 1
             }
         switch strategy {
         case .cold:

--- a/ReceiverTests/ReceiverTests+Performance.swift
+++ b/ReceiverTests/ReceiverTests+Performance.swift
@@ -18,4 +18,26 @@ class ReceiverTests_Performance: XCTestCase {
             }
         }
     }
+    
+    func test_listen_performance() {
+        self.measure {
+            let numberOfListeners = 200000
+            let (transmitter, receiver) = Receiver<Int>.make()
+            var called = 0
+            
+            for _ in 1...numberOfListeners {
+                receiver.listen { wave in
+                    XCTAssertTrue(wave == 1)
+                    called = called + 1
+                }
+            }
+            
+            transmitter.broadcast(1)
+            XCTAssertEqual(called, numberOfListeners)
+
+            transmitter.broadcast(1)
+            XCTAssertEqual(called, numberOfListeners*2)
+        }
+    }
+
 }

--- a/ReceiverTests/ReceiverTests+Performance.swift
+++ b/ReceiverTests/ReceiverTests+Performance.swift
@@ -19,24 +19,35 @@ class ReceiverTests_Performance: XCTestCase {
         }
     }
     
-    func test_listen_performance() {
+    func test_listen_and_dispose_performance() {
         self.measure {
-            let numberOfListeners = 200000
+            let numberOfListeners = 10000
+            var numberOfDisposes = 0
             let (transmitter, receiver) = Receiver<Int>.make()
             var called = 0
+            var disposables = [Disposable]()
             
-            for _ in 1...numberOfListeners {
-                receiver.listen { wave in
+            for i in 1...numberOfListeners {
+                
+                let disposable = receiver.listen { wave in
                     XCTAssertTrue(wave == 1)
                     called = called + 1
+                }
+                
+                disposables.append(disposable)
+                
+                if i % 3 == 0 && disposables.count > 0 {
+                    let d = disposables.remove(at: Int.random(in: 0..<disposables.count))
+                    d.dispose()
+                    numberOfDisposes += 1
                 }
             }
             
             transmitter.broadcast(1)
-            XCTAssertEqual(called, numberOfListeners)
+            XCTAssertEqual(called, numberOfListeners-numberOfDisposes)
 
             transmitter.broadcast(1)
-            XCTAssertEqual(called, numberOfListeners*2)
+            XCTAssertEqual(called, (numberOfListeners-numberOfDisposes)*2)
         }
     }
 


### PR DESCRIPTION
Previous strategy was failing with newer swift versions, this is the same issue as #11. 
**[Edit]** ~~It seems that `Dictionary.keys` is somehow not atomic.~~ This is not true, see below **[/Edit]**
I have not checked the diffs to get to the root cause, however this now passes tests and I added
a performance test just to check that it does not add any overhead.